### PR TITLE
makefile and small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.git
+htmlc
 .svn
 .vscode
 .idea

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-go get -u
-go mod tidy
-
-cd ./exec
-go build -o ../htmlc
-cd ../

--- a/makefile
+++ b/makefile
@@ -1,0 +1,4 @@
+build all:
+	go get -u
+	go mod tidy
+	go build exec -o htmlc

--- a/readme.md
+++ b/readme.md
@@ -49,13 +49,13 @@ and "--out" is set to the same directory, with the file name set to the base fol
 You can also call this method without the "--src" or "--port"
 
 ```shell
-./htmlc --src="/var/www/html"
+./htmlc /var/www/html
 # is equivalent to
 ./htmlc --src="/var/www/html"
 
-./htmlc --port="3000"
-# is equivalent to
 ./htmlc 3000
+# is equivalent to
+./htmlc --port="3000"
 
 # so you can use the method like this
 ./htmlc /var/www/html 3000


### PR DESCRIPTION
- using a makefile instead
- small fixes to .gitignore
- small fix for readme.md

Maybe the makefile lacks the "install" command. I guessed it doesn't need to be there, since it was not in the build.sh. Please change/modify the installation part of the readme to make it more obvious what it is needed to install the dependencies and how to build.
Only "make" is needed as command, when using makefies.
Compiled binaries should be somewhere else, like as a release asset.

Other than that, just small changes for beginner mistakes.